### PR TITLE
Use portal for modal

### DIFF
--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -9,6 +9,7 @@ interface Props {
   body: React.ReactNode;
   confirmText?: React.ReactNode;
   cancelText?: React.ReactNode;
+  disablePortal?: boolean;
 }
 
 function Modal(props: Props) {
@@ -19,6 +20,7 @@ function Modal(props: Props) {
     body,
     confirmText = "OK",
     cancelText = "Cancel",
+    disablePortal = false,
   } = props;
 
   const ref = useRef<Element | null>(null);
@@ -29,51 +31,50 @@ function Modal(props: Props) {
     setMounted(true);
   }, []);
 
-  return mounted && ref.current
-    ? createPortal(
-        <div
-          className={`modal modal-bottom sm:modal-middle ${
-            isVisible ? "modal-open" : ""
-          }`}
+  const modal = () => (
+    <div
+      className={`modal modal-bottom sm:modal-middle ${
+        isVisible ? "modal-open" : ""
+      }`}
+    >
+      <div className="modal-box">
+        <button
+          className="btn btn-sm btn-circle absolute right-2 top-2"
+          onClick={() => onClose(false)}
         >
-          <div className="modal-box">
-            <button
-              className="btn btn-sm btn-circle absolute right-2 top-2"
-              onClick={() => onClose(false)}
-            >
-              x
-            </button>
-            {typeof title === "string" ? (
-              <Text size="lg" weight="bold">
-                {title}
-              </Text>
-            ) : (
-              title
-            )}
-            {typeof body === "string" ? (
-              <Text className="py-4">{body}</Text>
-            ) : (
-              body
-            )}
-            <div className="modal-action justify-center sm:justify-end">
-              <button
-                className="btn btn-primary flex-1 sm:flex-none sm:w-40"
-                onClick={() => onClose(true)}
-              >
-                {confirmText}
-              </button>
-              <button
-                className="btn btn-neutral btn-outline flex-1 sm:flex-none sm:w-40"
-                onClick={() => onClose(false)}
-              >
-                {cancelText}
-              </button>
-            </div>
-          </div>
-        </div>,
-        document.body
-      )
-    : null;
+          x
+        </button>
+        {typeof title === "string" ? (
+          <Text size="lg" weight="bold">
+            {title}
+          </Text>
+        ) : (
+          title
+        )}
+        {typeof body === "string" ? <Text className="py-4">{body}</Text> : body}
+        <div className="modal-action justify-center sm:justify-end">
+          <button
+            className="btn btn-primary flex-1 sm:flex-none sm:w-40"
+            onClick={() => onClose(true)}
+          >
+            {confirmText}
+          </button>
+          <button
+            className="btn btn-neutral btn-outline flex-1 sm:flex-none sm:w-40"
+            onClick={() => onClose(false)}
+          >
+            {cancelText}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+
+  if (disablePortal) {
+    return <>{modal()}</>;
+  }
+
+  return mounted && ref.current ? createPortal(modal(), document.body) : null;
 }
 
 export default Modal;

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -1,4 +1,5 @@
-import React from "react";
+import React, { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import Text from "../Text/Text";
 
 interface Props {
@@ -20,44 +21,59 @@ function Modal(props: Props) {
     cancelText = "Cancel",
   } = props;
 
-  return (
-    <div
-      className={`modal modal-bottom sm:modal-middle 
-      ${isVisible ? "modal-open" : ""}
-    `}
-    >
-      <div className="modal-box">
-        <button
-          className="btn btn-sm btn-circle absolute right-2 top-2"
-          onClick={() => onClose(false)}
+  const ref = useRef<Element | null>(null);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    ref.current = document.querySelector<HTMLElement>("body");
+    setMounted(true);
+  }, []);
+
+  return mounted && ref.current
+    ? createPortal(
+        <div
+          className={`modal modal-bottom sm:modal-middle ${
+            isVisible ? "modal-open" : ""
+          }`}
         >
-          x
-        </button>
-        {typeof title === "string" ? (
-          <Text size="lg" weight="bold">
-            {title}
-          </Text>
-        ) : (
-          title
-        )}
-        {typeof body === "string" ? <Text className="py-4">{body}</Text> : body}
-        <div className="modal-action justify-center sm:justify-end">
-          <button
-            className="btn btn-primary flex-1 sm:flex-none sm:w-40"
-            onClick={() => onClose(true)}
-          >
-            {confirmText}
-          </button>
-          <button
-            className="btn btn-neutral btn-outline flex-1 sm:flex-none sm:w-40"
-            onClick={() => onClose(false)}
-          >
-            {cancelText}
-          </button>
-        </div>
-      </div>
-    </div>
-  );
+          <div className="modal-box">
+            <button
+              className="btn btn-sm btn-circle absolute right-2 top-2"
+              onClick={() => onClose(false)}
+            >
+              x
+            </button>
+            {typeof title === "string" ? (
+              <Text size="lg" weight="bold">
+                {title}
+              </Text>
+            ) : (
+              title
+            )}
+            {typeof body === "string" ? (
+              <Text className="py-4">{body}</Text>
+            ) : (
+              body
+            )}
+            <div className="modal-action justify-center sm:justify-end">
+              <button
+                className="btn btn-primary flex-1 sm:flex-none sm:w-40"
+                onClick={() => onClose(true)}
+              >
+                {confirmText}
+              </button>
+              <button
+                className="btn btn-neutral btn-outline flex-1 sm:flex-none sm:w-40"
+                onClick={() => onClose(false)}
+              >
+                {cancelText}
+              </button>
+            </div>
+          </div>
+        </div>,
+        document.body
+      )
+    : null;
 }
 
 export default Modal;

--- a/src/pages/index.page.tsx
+++ b/src/pages/index.page.tsx
@@ -179,6 +179,19 @@ export default function Home() {
           </div>
 
           <div>
+            <button className="btn" onClick={() => setIsModalVisible(true)}>
+              Modal without Poratl
+            </button>
+            <Modal
+              isVisible={isModalVisible}
+              onClose={() => setIsModalVisible(false)}
+              disablePortal
+              title="This is a modal without portal"
+              body="This is the body of the modal. And this is a very long text to test the modal. This is the body of the modal. And this is a very long text to test the modal."
+            />
+          </div>
+
+          <div>
             <button
               className="btn"
               onClick={() => setIsConfirmationModalVisible(true)}

--- a/src/stories/Modal.stories.tsx
+++ b/src/stories/Modal.stories.tsx
@@ -18,3 +18,17 @@ Default.args = {
   confirmText: "OK",
   cancelText: "Cancel",
 };
+
+export const PortalDisabled: ComponentStory<typeof Modal> = (args) => (
+  <Modal {...args} />
+);
+
+PortalDisabled.args = {
+  isVisible: true,
+  onClose: () => {},
+  disablePortal: true,
+  title: "Modal Title",
+  body: "Modal Body",
+  confirmText: "OK",
+  cancelText: "Cancel",
+};


### PR DESCRIPTION
- It is a common practice to use a portal for modals to avoid modals being rendered within the dom tree along with the page's content. Portal allows rendering the modal content outside the tree of the page.
- Current PR renders modal on the client side, in the dom tree, outside the page content using a portal.